### PR TITLE
add support for intl-* URLs

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@ browser.webRequest.onBeforeRequest.addListener(
   ({ url }) => {
     const [fullMatch, type, identifier] =
       url.match(
-        /open\.spotify\.com\/(track|album|artist|playlist|concert|episode|show|user)\/([^\&\#\/\?]+)/i
+        /open\.spotify\.com\/(?:intl-[a-z]{2}\/)?(track|album|artist|playlist|concert|episode|show|user)\/([^\&\#\/\?]+)/i
       ) || [];
 
     return { redirectUrl: `spotify:${type}:${identifier}` };
@@ -11,7 +11,11 @@ browser.webRequest.onBeforeRequest.addListener(
     urls: ["*://open.spotify.com/track/*", "*://open.spotify.com/album/*",
   "*://open.spotify.com/artist/*", "*://open.spotify.com/playlist/*",
   "*://open.spotify.com/concert/*", "*://open.spotify.com/episode/*",
-  "*://open.spotify.com/show/*", "*://open.spotify.com/user/*"],
+  "*://open.spotify.com/show/*", "*://open.spotify.com/user/*",
+  "*://open.spotify.com/intl-*/track/*", "*://open.spotify.com/intl-*/album/*",
+  "*://open.spotify.com/intl-*/artist/*", "*://open.spotify.com/intl-*/playlist/*",
+  "*://open.spotify.com/intl-*/concert/*", "*://open.spotify.com/intl-*/episode/*",
+  "*://open.spotify.com/intl-*/show/*", "*://open.spotify.com/intl-*/user/*"],
     types: [
       "main_frame",
       "xmlhttprequest"]


### PR DESCRIPTION
I've been encountering URLs with `/intl-de/` prefixes, e.g. https://open.spotify.com/intl-de/track/1XK0SrwnujLMZv22WjVQU9

The current rules don't work with them, so here's a patch for that. :)
Tested with Firefox 123.0b3.